### PR TITLE
Update lazy-imports to 1.2.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,25 +1,26 @@
 {% set name = "lazy-imports" %}
-{% set version = "0.3.1" %}
+{% set version = "1.2.0" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/lazy_imports-{{ version }}.tar.gz
-  sha256: 636624104bf45b09761323e06292927832aca067c3c199e5de483738789aeb21
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/lazy_imports-{{ version }}.tar.gz
+  sha256: 3c546b3c1e7c4bf62a07f897f6179d9feda6118e71ef6ecc47a339cab3d2e2d9
 
 build:
-  noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  skip: true  # [py<310]
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 0
 
 requirements:
   host:
-    - python >=3.6
+    - python
     - pip
+    - setuptools
   run:
-    - python >=3.6
+    - python
 
 test:
   imports:
@@ -30,10 +31,16 @@ test:
     - pip
 
 about:
-  home: https://github.com/telekom/lazy-imports
+  home: https://github.com/bachorp/lazy-imports
   summary: Tool to support lazy imports
+  description: |
+    lazy-imports provides utilities for deferred module loading in Python,
+    reducing startup time by only importing modules when they are first accessed.
   license: Apache-2.0
+  license_family: Apache
   license_file: LICENSE
+  doc_url: https://github.com/bachorp/lazy-imports
+  dev_url: https://github.com/bachorp/lazy-imports
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
lazy-imports 1.2.0

**Destination channel:** defaults

### Links

- [PKG-13008](https://anaconda.atlassian.net/browse/PKG-13008)
- [Upstream repository](https://github.com/bachorp/lazy-imports)
- [Upstream changelog/diff](https://github.com/bachorp/lazy-imports/compare/v0.3.1...v1.2.0)

### Explanation of changes:

- Version bump from 0.3.1 to 1.2.0
- Update Python requirement to >=3.10 (upstream change)
- Add `setuptools` to host requirements (build backend)
- Update `home` URL to new upstream repo (telekom → bachorp)

This is a dependency of haystack-ai (PKG-6406). Build order: lazy-imports → haystack-ai → haystack-experimental.

[PKG-13008]: https://anaconda.atlassian.net/browse/PKG-13008?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PKG-6406]: https://anaconda.atlassian.net/browse/PKG-6406?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ